### PR TITLE
Add FTB-chunks and make it optional (default true)

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -2,255 +2,260 @@ hash-format = "sha256"
 
 [[files]]
 file = "config/hextweaks.json"
-hash = "933db55075e1a22b595adcab1027d945d1563bd1b51bbe2b2bb1042b84a8957f"
+hash = "ea0430aeec9a1c4136d5eadb3f810d4f804bb7d20ae767f963392985cc58f564"
 
 [[files]]
 file = "config/plethora.hocon"
-hash = "0d6db9e313618e28354c6229918f5d766d4345d17b2061d166829dec83a979ac"
+hash = "5eb842e0adc4a9ddab0d4700dbcfa6fd019ed96026de8709c105e2cf715d4d3c"
 
 [[files]]
 file = "mods/absolute-ultracraft.pw.toml"
-hash = "16e6050845f0bfad70d25226fdbba2502fee88cb7443ff47cc63b1a803f5c45a"
+hash = "9d996881d3b2e5aa28df463224c770be02fc309f586581884374179efe4b7485"
 metafile = true
 
 [[files]]
 file = "mods/ae2.pw.toml"
-hash = "1e494492653e881a139969a339e444b76ebfc53f1fe90769e03c374aa446e327"
+hash = "f9d7d2804ef308372b22cace4fb22ef76992da3a5ac702f54abfcdf3f3631ec5"
 metafile = true
 
 [[files]]
 file = "mods/appleskin.pw.toml"
-hash = "0d72044f88935675985397478ca839878bfbf03feab46e9667e81d4c955ae68d"
+hash = "023925c73ad0fd7eced08160c3174449c27b7de5512f37b5e161a4234c64db06"
 metafile = true
 
 [[files]]
 file = "mods/applied-botanics.pw.toml"
-hash = "eb4377f8e33d5040f2aaf9fde5c5799159db864b91fab6908ef12bb1836483e3"
+hash = "bc125b9b2745bc062daab145efa92c95be45909d2ff16ca484405af78d2bae72"
 metafile = true
 
 [[files]]
 file = "mods/architectury-api.pw.toml"
-hash = "13cb21e09b9d0d6622359f24f0bfed0e4123fcbaf7e65a1eb7e5396c47a56349"
+hash = "f04b4925e05e0b01308abcd194fc724a7a211b86ca94771e1141c445c967b6c3"
 metafile = true
 
 [[files]]
 file = "mods/armourers-workshop.pw.toml"
-hash = "93b320b0be226ab43d3c79ecf488fc71a980fe9850a1a2bc9325684beae3b84a"
+hash = "c437961127d71de7e5f3eeef3cc1437b47dc59fce654035a9af98e66955f6fc7"
 metafile = true
 
 [[files]]
 file = "mods/bookshelf-lib.pw.toml"
-hash = "2f6093d5d0bca4253ca66a4f4909bac6fa36e2e6a9c0a54fb5c56d7707b6283f"
+hash = "f53e1bc1d791b7839b1fe00a50e79682ba5588d3591ff4978e06616cb420607d"
 metafile = true
 
 [[files]]
 file = "mods/botania.pw.toml"
-hash = "2b115c22f739c472bc46399a036b63c59fd418e77fca52255058929b3986f2ec"
+hash = "ff9ba6b7866b6173d1e4502b54ccc5331362db5308bf801aabf65614da4e9e99"
 metafile = true
 
 [[files]]
 file = "mods/botany-pots.pw.toml"
-hash = "395c952204f60b3ac305de712d1e127e47168492b0e02fa0d11fa04783a2971a"
+hash = "7ac5efe48c34025f70c98d9fd6633423cc55e634e572c86afe7e33f445857618"
 metafile = true
 
 [[files]]
 file = "mods/botany-trees.pw.toml"
-hash = "c87840bdb000634c405661142235adb8ef8587ffa91d6bbf5732f2e2c4a1863b"
+hash = "d8002a19dccc37af4d036807e12769742564229c28c70eaef33a27ecbf1828df"
 metafile = true
 
 [[files]]
 file = "mods/cardinal-components-api.pw.toml"
-hash = "50e3b067e93d3e6683d540edc4d046ed7b6b5fbb31409df1727b120f225b1975"
+hash = "f42d3641b199518a574388e34a2812e70cb672d988ef4a2674a7e5f8b9c090f2"
 metafile = true
 
 [[files]]
 file = "mods/carry-on.pw.toml"
-hash = "94fbe9655850d99ed2a950e6b59c9cbfabfc21d859c7920c4a8b21101f5981b7"
+hash = "393ac4e5001d0a95f643a0527fe7e7587399d1238d13610a89f687fb69cc91ae"
 metafile = true
 
 [[files]]
 file = "mods/cc-tweaked.pw.toml"
-hash = "aa6fdb0075cadc58767cd4c173f7d275cc52859609c2f4832afe0463bfd94c12"
+hash = "4981880c99073da30a8580ec849525454ffbbffbbcfd9e5f3fae32de80b54718"
 metafile = true
 
 [[files]]
 file = "mods/chest-tracker.pw.toml"
-hash = "2bbc76335047a3ba583afd60ad53b33855454df8dfddf488e7132ccfba32e148"
+hash = "42732832d1d4aba8c3f7787173850da1b6430bb3c0133f487d10e332cf2b1ac9"
 metafile = true
 
 [[files]]
 file = "mods/chunk-loaders.pw.toml"
-hash = "c0a9f74591d0a2ea22da7775d167c00c877959a69d6ef51d6f78ce52d4c896ae"
+hash = "c25e7f33a1371dbb629f3cd968a84ebe9e0c7566b99aff92b698cf698545afcd"
 metafile = true
 
 [[files]]
 file = "mods/chunkumulator.pw.toml"
-hash = "da0136131367a12fc30d78e73e631ddf172a32f5f1021cf78dbf2fc9e804a3dd"
+hash = "0f749ab6c27566ca98dc95db64db6c3b5b02450b744167a00fd7236501d505cb"
 metafile = true
 
 [[files]]
 file = "mods/cloth-config.pw.toml"
-hash = "a89dfcc985612a275975d4823a24fc3dceb244bacb2e8f81bd459283bf1b9fe9"
+hash = "bf217f6c8a57689df490f7b0793f51227feb4d947d61a84ed9af6b34a9b3631f"
 metafile = true
 
 [[files]]
 file = "mods/clumps.pw.toml"
-hash = "524505b468ca28db75538936dbaea65fc42d13d07e821ed8c054fe7146044535"
+hash = "48c1da6c74c551942a6cb6b1172e65dbcc7a3c248a87c201234165bcc4df0220"
 metafile = true
 
 [[files]]
 file = "mods/collective.pw.toml"
-hash = "14dee244835896ecf74aeb0e2e9f86176ec208c9b981471cd8a599bab5966a9d"
+hash = "1fc8385bbc5d488d171f1015747251e2b313b1ab5b80b8c7850603e3d45b2b0c"
 metafile = true
 
 [[files]]
 file = "mods/computer-cartographer.pw.toml"
-hash = "e567a249b43bf4a6fdc41409be12be3bd775161d561f1889a0bcc18afc829b31"
+hash = "5c67c4849c15e913f03367d01a607a8e4b49bc33f418d286e03f1689c619be15"
 metafile = true
 
 [[files]]
 file = "mods/controlling.pw.toml"
-hash = "0360f47c1afd7385518db9df5d809344e1bcdc163e940a8744ee61b6d745b6ce"
+hash = "fde6d6dac9f1091cb23b62d0ce75d23a72ec0dea91ff80b781037f5dbc5d83f8"
 metafile = true
 
 [[files]]
 file = "mods/cosmetic-armor.pw.toml"
-hash = "b7554f6904cd09f88067fa11b7edbe1d8ff88f75bfb4a437d19b50dcae607b61"
+hash = "bd8fb060b34713e54d6c8179e54c30e7d5b6085c93e2c036fd203ef59817d081"
 metafile = true
 
 [[files]]
 file = "mods/crafttweaker.pw.toml"
-hash = "8fafe031d6b7bcbd6b01665842e1e68d64b6a7dbbd6477c0557e77a88d729c40"
+hash = "c62987fa06bb15617a25e8b0d0752daa21ba61249da5c93131f2a807afe80a9c"
 metafile = true
 
 [[files]]
 file = "mods/create-fabric-sodium-fix.pw.toml"
-hash = "0dc9fad2f8048eab5f3ba5d1ee71884046fea3de7e8432df5d1ab66b6e084c85"
+hash = "2cfc83ac38f5a9947297130bd63c25429c0c2fd567d67445820da83b8263c1b0"
 metafile = true
 
 [[files]]
 file = "mods/create-steam-n-rails.pw.toml"
-hash = "2995bd6fc4d6cfb207625005e7392fc09aefe226a0441cceca6687dfc1883ad6"
+hash = "dabeebb222c430adb7a64db523d8c6c8ca9f29ccddb1139a6149ed1d27ec1d34"
 metafile = true
 
 [[files]]
 file = "mods/createaddition.pw.toml"
-hash = "ca80c183f9444b19fcd7e5e654dad1c7b208affe18f7e6c2cff42642e8c3951f"
+hash = "0278deaa1f16b1fe0b10d604d7c4254450e1e6d4c6917ac9b476ecbd4ecb1567"
 metafile = true
 
 [[files]]
 file = "mods/cupboard.pw.toml"
-hash = "205ab6a8e776226ba839f3c03a80743dc7e963f0b91477c831e98e9b806f91ab"
+hash = "e7ed6925a0b7b3d738c6ee9b4b34bbd3e70c97d3772e643d22951adecad83d58"
 metafile = true
 
 [[files]]
 file = "mods/distanthorizons.pw.toml"
-hash = "3f2ba4e458ea519a43e1c02f621c9f3e625dcb439353e5768a622bbfd515e278"
+hash = "ab51e5eb352a8d8396caa737cbb8722ad0b94c001feb3b577a98f920cdb94753"
 metafile = true
 
 [[files]]
 file = "mods/do-a-barrel-roll.pw.toml"
-hash = "75f838bc322e1d9acb4266c97fd40458b355dbfee54180e65a41e999913078a2"
+hash = "9d57217b9eddeed5c166e303371ad7c5c5685ffa4b6fbd0dda877828981d43ef"
 metafile = true
 
 [[files]]
 file = "mods/ducky-periphs.pw.toml"
-hash = "ad0b1c92bf3db21f58b6c609e2da6cd303afedda9973000456e7e3886f906e89"
+hash = "2cce555866c176475052f4872b35e3ec5aa0516965259406836995823c274532"
 metafile = true
 
 [[files]]
 file = "mods/easy-shulker-boxes.pw.toml"
-hash = "24d0280548982225903b9ff97b97924f535db1e6a4e76947b9da70618926d857"
+hash = "d8953137d0a2297e0c69085331b7f6d4806a6de5e424da7b345ccd24c0a984b7"
 metafile = true
 
 [[files]]
 file = "mods/ebe.pw.toml"
-hash = "b8270928d44781b9e59982d376bb3cc0d24089ceebef3c79d3e1e881ba7ece60"
+hash = "8df56d685d7d3913ed73d9669a1147bdca2ca053641f656ac5e9dec2a174eb97"
 metafile = true
 
 [[files]]
 file = "mods/elytra-trims.pw.toml"
-hash = "03cdf4c69f8a80171e7a3998238550cc7f3bf7f321e179cdcd63f00ec481fd20"
+hash = "53eba8a974b056e19e3cefd3e9c398289d29abad29a1535904e5b0bbf82df2f9"
 metafile = true
 
 [[files]]
 file = "mods/emi-enchanting.pw.toml"
-hash = "f88b04c5b537da9f1d032e3c9dff56648d9c19b7658af065f11d618f5c1c3fdd"
+hash = "2e2f9f6bb7a29aee2ff81f8e7839d84966d3d0d8df57fa07dd4a3c99169df516"
 metafile = true
 
 [[files]]
 file = "mods/emi-loot.pw.toml"
-hash = "6ed9dba064110665c3dcf26be139c68b290ef0079e8aece1d2aced9484ebf85b"
+hash = "6a0f9199bd40adf03770f8087b391ea2f4db6e61d72442755b122fdacf90a077"
 metafile = true
 
 [[files]]
 file = "mods/emi.pw.toml"
-hash = "89556771a29b247e12fc58be469262f67ab1b736854381ae6cc4a7a1158ecebd"
+hash = "ac2d540312a56b6220e5826f939d0db6825ab73361f24e42298aa3b4b763c1ad"
 metafile = true
 
 [[files]]
 file = "mods/emitrades.pw.toml"
-hash = "a55d562fcd6be9796e8cc162b83b5745efd83254fae44bf5a4d85d0fe6c97fcb"
+hash = "d7650fa1a4c14276d76f0767d8825444a176349ac3ae2ae0e0ce96faf9e447ff"
 metafile = true
 
 [[files]]
 file = "mods/estrogen.pw.toml"
-hash = "10564bf0380d7f6558a962c1cf3f6c63a319c07020321b139ba7e55cc82cfa60"
+hash = "520b08a699dc4714822f73abfdbb1d95501fcd1d0223d920633b6fb1db28d736"
 metafile = true
 
 [[files]]
 file = "mods/fabric-api.pw.toml"
-hash = "b2add68278027f1d23ca7fd0440ea686faa37d6ccefd55dc064bac9e6f93de54"
+hash = "c6377320a4db1285be52c5b76009390f6cdbe333687170868f09de1c2a5a9b81"
 metafile = true
 
 [[files]]
 file = "mods/fabric-language-kotlin.pw.toml"
-hash = "d74850aaf1ed5a53805d523aa2b624f58c43813446be0b6c066a599c80d704e6"
+hash = "cfc600f1d3fb8557d4b123b0cedc7e13010655156248fd31d80508679c3f2fad"
 metafile = true
 
 [[files]]
 file = "mods/fabrication.pw.toml"
-hash = "fc0e8c398941ba7e24e649fee05edadf64f21f686fa6b3ce557c5cd3002b6d72"
+hash = "30d2ccbb0444eb8695e71a1bd3196993d78c46fef0465b2fca86266b5de5575b"
 metafile = true
 
 [[files]]
 file = "mods/farmers-delight-fabric.pw.toml"
-hash = "dc4a6ad558baacff8619bcb127784bfa27eb6ca4c177eae12d86b833eca80694"
+hash = "a7ce66ba0af33904a2d3f0d18ceb2f2904f0f18fb209d54d1f1dfd50610c8b72"
 metafile = true
 
 [[files]]
 file = "mods/faux-custom-entity-data.pw.toml"
-hash = "a4da8bc46ad51d30597bd2235add659f0ee49123a7140487de7d127659a87e4b"
+hash = "390d7fe3f9d4759b8a26951728ce8fc429dda475bab2b859efb27d5c34f78f6d"
 metafile = true
 
 [[files]]
 file = "mods/ferrite-core.pw.toml"
-hash = "39a6a39433b1b104bfafafcd60a8171f866daa2ebefffd64df822d0e69288e3a"
+hash = "a31b4ee2eb163779aec7bdfd40f23a5295da9eeb5fde086166d26058549c1565"
 metafile = true
 
 [[files]]
 file = "mods/figura.pw.toml"
-hash = "75ffe202cd8947bbbb748a46bcd9d1cfb55d34a2fc95909b3001ac8433625fb7"
+hash = "c4d0665c054ab01fe1b32bdf3889179c84cca7391a25a49e425f4e51dff250fb"
 metafile = true
 
 [[files]]
 file = "mods/forge-config-api-port.pw.toml"
-hash = "129bb8b135edc60038f021b693f5b88a0067b722f326e0d6067112243774289b"
+hash = "d79cf846404ebbb11c86c4c3d1fe5a4ac5d01cd62c20ef0f0aa139997f6db39d"
+metafile = true
+
+[[files]]
+file = "mods/ftb-chunks-fabric.pw.toml"
+hash = "2c678290203916345c35addde0e1d653c869a0939166f2acec71ebcf809ff40d"
 metafile = true
 
 [[files]]
 file = "mods/ftb-library-fabric.pw.toml"
-hash = "a9da0392540d6ced5b66447b8fecd8d4362c693164ef0187379bd56f012830cc"
+hash = "25e214c1df49cd933a4e1df0da8aaa09dfb654209beae9109beccc22bd0e3173"
 metafile = true
 
 [[files]]
 file = "mods/ftb-teams-fabric.pw.toml"
-hash = "f50b4146e7cf0a045a593aa23f849eaafe9980b1fc82a55dd1b3ba08a3193253"
+hash = "7b646f6272db8bf42f88cd18396f67c54006bd3d055536ee9ce61e3eb02eb739"
 metafile = true
 
 [[files]]
 file = "mods/geckolib.pw.toml"
-hash = "f28b7f16e0b89f86a625691db438fd69c1029f0fa1aea46bd415036a423a2880"
+hash = "01c94b9e448dd69dafd8c8209140d94153f21d798a087b3e0341cab9f57be8a8"
 metafile = true
 
 [[files]]
@@ -259,7 +264,7 @@ hash = "934a3dbd3118f5982527dff8735aa93b3a9a4ebe8cd5f575fd6e570d84af0e33"
 
 [[files]]
 file = "mods/hexcasting.pw.toml"
-hash = "7f664a1b293b31699f1263340c24010d5312f5dd0eba6bb211d07503315caf71"
+hash = "40ce6164211af3091e963ed43b4dac937e8779f0704e9f4bdf0e3624295b2708"
 metafile = true
 
 [[files]]
@@ -272,77 +277,77 @@ hash = "118c3efb53e7cf1ac1ee86d729083da9f01ab5508d21f9a56372faf70f6fbb73"
 
 [[files]]
 file = "mods/indium.pw.toml"
-hash = "db0bc674543cda857cee08b1164435fc659f796620747c0073e2415258b15406"
+hash = "3397de4d66c6e1553e6c3d224dbd001c7730e5d07080d8aee9acca5673013c7b"
 metafile = true
 
 [[files]]
 file = "mods/inventory-profiles-next.pw.toml"
-hash = "2704ac777bf166ced4662347d685b9df4735e8741084a04522def938d249746e"
+hash = "63858374211b992650f8c9839bcf67b04e25fcf8dc249ad75b592d8e88925852"
 metafile = true
 
 [[files]]
 file = "mods/jade.pw.toml"
-hash = "bd14735296607c2f58e3130748610d08ab6407afcb1d7cd168e856a0012173a7"
+hash = "264a76d6fd9770933f20be0c366d0e26ea23f6a2d82d820905c12cfd42e8b647"
 metafile = true
 
 [[files]]
 file = "mods/jei.pw.toml"
-hash = "3e1a381807b8bfe1abb6be6b043b64d9426097bb4ea16c6aa956f6a151f5c72e"
+hash = "ec16bb8c313a4ff52176771efff08963eade50a44ce12293b9548a7cfd87659d"
 metafile = true
 
 [[files]]
 file = "mods/krypton.pw.toml"
-hash = "71ef7cc16632c0039fe194183b5885968c6d740aaa67a58000653ae0cb40b882"
+hash = "9d29339a6ae2413f2b1e77d81fec8b4288dcc9de6aa848fc2ed52028b17ea8e3"
 metafile = true
 
 [[files]]
 file = "mods/libipn.pw.toml"
-hash = "6332607e5399b318c9b39b14a9c6e36428cd52dd96b65f592fff9eb15117fc3f"
+hash = "5343cff99c91a10b17331be6582c229f50ef93fb24928d62d2b84861d7782a44"
 metafile = true
 
 [[files]]
 file = "mods/libjf.pw.toml"
-hash = "fd1b685219022148a51b5834f9c424a148025ef673ce50c935c2388e08d0040a"
+hash = "1d13e0158816c441d1f850f5c393404a5dea976ea98896a0ef90a8c93aee57c2"
 metafile = true
 
 [[files]]
 file = "mods/lootr.pw.toml"
-hash = "8f8650f906d35b4c6d7fb0040ae55fcfcfe51788d991bde0ea8415b66acabf29"
+hash = "07a08a0c696489ebe77336459ff057e6fb72c16e5efb8c61ed8b747c53622c5d"
 metafile = true
 
 [[files]]
 file = "mods/max-health-fix.pw.toml"
-hash = "a5a93d32d5f286815e3d35a5d6b5381492db49607e5f3613ee7af53246b6f6af"
+hash = "2826f283a3fc4a4835fe373038433f161fcdfd4d09ed13f37e34f8afaeef3446"
 metafile = true
 
 [[files]]
 file = "mods/memoryleakfix.pw.toml"
-hash = "3c0945a312aca06a2185b00cb03ae482949b008d72614497148aa2df301af019"
+hash = "5b79c8e36f9204ee4a6f6d2eb6e3665d42fb09ebe4fc79b85e2951697597aca7"
 metafile = true
 
 [[files]]
 file = "mods/minecraft-comes-alive-reborn.pw.toml"
-hash = "f1d7497ddecfbca9b64e46ae451456720c72ba34f8fe2fa21f29700505544122"
+hash = "fbb34a78b43090a18b5049a186c65ce0034ad9bb9be368cc4e83c60181958653"
 metafile = true
 
 [[files]]
 file = "mods/mixintrace.pw.toml"
-hash = "b89656eaf7e4404d8d2c5b1e1155aae85a839939f83cab6d1b5e791412ad5f86"
+hash = "7dc0119dac2246a00a28a73c128bc2e5275fa8c61dfb6024ef75476691c95a00"
 metafile = true
 
 [[files]]
 file = "mods/mmmmmmmmmmmm.pw.toml"
-hash = "32f2425608f08f02ced7d11816cc03501e89dd3767fa9a28f0e67e48f16bc101"
+hash = "1e07944c3fdf177ccc0c1cc65ef6cbd81648df070ff169d95f214b2fc9a2f349"
 metafile = true
 
 [[files]]
 file = "mods/modmenu.pw.toml"
-hash = "4cd171d3f5f3e1d2948cb1b0062e742a5e85110c9e9a668f9aed5b0cebcb9c97"
+hash = "0e76e306423a6c04fc5496bc5321638be9b06149e9b4b9f267fad3fabca3bbae"
 metafile = true
 
 [[files]]
 file = "mods/moonlight.pw.toml"
-hash = "7b2f178be51b01b0ce78c3f8e1d9f4c3da9b447726fb6b5acefeae4a4900e0cf"
+hash = "acffd6d104fe639aa1f108c43e07a63923ab08ba23b0274662fcc82d5247bf4e"
 metafile = true
 
 [[files]]
@@ -351,52 +356,52 @@ hash = "9cc2e20e1b067944ba6ef76b9751705b172a6ebf7766bf62b5d87c8875f3d166"
 
 [[files]]
 file = "mods/no-chat-reports.pw.toml"
-hash = "7ca62a9da5c2ec9f0a8bed5394021c959e90077db16b313be44f4c8736f7fbf5"
+hash = "664d2205458d7a642031de163f41b95bcf6eea1946e0475105df81a79f39b1eb"
 metafile = true
 
 [[files]]
 file = "mods/observable.pw.toml"
-hash = "f021bc3633c4730b9e487c8e4cb566e438c3c90722e89f52ca28e72c2eb5a6d5"
+hash = "3c30d4d16596d4f0aa31d6283fb34dcca4a0062449a67003a38f8045c8d53591"
 metafile = true
 
 [[files]]
 file = "mods/owo-lib.pw.toml"
-hash = "28b3e0806647eb166e942cf6552993bb6d666949c53f0d51927bdfb063cb6cc4"
+hash = "9809b02733003cfd11b32eadfce975c60d1fe7fb1e28342c7e650a6dfac28631"
 metafile = true
 
 [[files]]
 file = "mods/packages.pw.toml"
-hash = "21fde8b12697f1a58de50f5b0c6c1db0df16c3c1c8f3240f5e4bf46744f1927f"
+hash = "4c5a056d7b581da617101b911af17677feacf151191bba976b4c956f08b3a9f8"
 metafile = true
 
 [[files]]
 file = "mods/packet-fixer.pw.toml"
-hash = "380dc01ccca1dd5f5acc54845b21ac1533bfcb048ca62b357b9b89eb10dbb07d"
+hash = "7e011ce4288f328eb0a938c8254eac232de00a2a1f554e1e2cd5d9024a2a760b"
 metafile = true
 
 [[files]]
 file = "mods/packwiz-server-updater.pw.toml"
-hash = "d013302f28b40676734df3b6fed35c1e0748c3452ed26508343a6d9656533ff1"
+hash = "916f46667f189e3bd44a20bdcae040ae77828ace357d9aa219f329a22e08afc1"
 metafile = true
 
 [[files]]
 file = "mods/paginated-advancements.pw.toml"
-hash = "385378a9a9d2a42a3e74876391aa527af960d5150f0cf7d0ec01073c3579ec37"
+hash = "4ec0d52d272bad8aaaf3ec55aec438f0e1e4514f5187b941b670a1f0174eba67"
 metafile = true
 
 [[files]]
 file = "mods/patchouli.pw.toml"
-hash = "89e5cab6f92dbcfd6c2c058fc9381869fde193a431c284dbb828833e881cd344"
+hash = "0fb3497cbc7aa0603222c0dda21fb534a4b417ecc48b3eb3ba5f10c3f2a49303"
 metafile = true
 
 [[files]]
 file = "mods/paucal.pw.toml"
-hash = "fee90eeefee1adbfce509b44bad47ac2e82c7571ffb69e2fadc36366bbe079ac"
+hash = "79bd788fcc53cd496df34f1e708f9534035dd1c4128e88c3feaffc5afdbd4b26"
 metafile = true
 
 [[files]]
 file = "mods/pehkui.pw.toml"
-hash = "f44c2e138b41270813fc1a1f1516ef44018f6ccfe83828deab77a196f746f5ae"
+hash = "47e053acf6a08d7a3ea529ff51c255ca481f4ae2d63b0049eb01190d16f45367"
 metafile = true
 
 [[files]]
@@ -405,117 +410,117 @@ hash = "3da39c503bdfc22aa88f550f6713f21df745d10bef2f1b7574f6c78ce3c7e408"
 
 [[files]]
 file = "mods/plethora-peripherals.pw.toml"
-hash = "634e9ad89419dd15aeffcaabe46396d00753e8bcb68a7e2c318061100a5ec10f"
+hash = "70aac16d0e95fdbbe21774cd90ed4563eeeea0dcc4b710221e203691d8e95ab7"
 metafile = true
 
 [[files]]
 file = "mods/polymorph.pw.toml"
-hash = "03c50c52bcdcc958ab261fdf157977356800ea7402f40bcc1c9552a465bb2ec6"
+hash = "2b4a589250293977d86e7ca5f55a18d68199b305d76d217a23f2f0691a6d873a"
 metafile = true
 
 [[files]]
 file = "mods/powerae2cc.pw.toml"
-hash = "6eb64220f87961daa78156f8d63b2f77a2870eeddf6d6af55af62eea407fe565"
+hash = "e44088cb11ccc4637ca7f3e8cbe189b028cad3fb252e2e895da7dd0169788555"
 metafile = true
 
 [[files]]
 file = "mods/puzzles-lib.pw.toml"
-hash = "3212f0db507b4091d07c75c88254f7aec18e96a27f648f76234cb7951a19ffca"
+hash = "67e9a60ef55ec432cedf0aa41f0ac4d3a154b76e35f5ab54b29bd184a9e3f525"
 metafile = true
 
 [[files]]
 file = "mods/raknetify.pw.toml"
-hash = "02421594640b86ccd43e888d0413ade610b4a87bb5a2325cccdfda0a502c5b61"
+hash = "f0431a402110a2bc74545a1ee167d81094607657ed10a4c966201ff0aefe10b4"
 metafile = true
 
 [[files]]
 file = "mods/resourceful-lib.pw.toml"
-hash = "8ac138bcb2e461b627f0dd7c681a07ac8396e65f8211c37e639acb4fed86754b"
+hash = "011246a0dd8e75faaa640f3e43bc089ae3d10c1290e8392b72a640423c528423"
 metafile = true
 
 [[files]]
 file = "mods/revelationary.pw.toml"
-hash = "c3e4cce180fa406e5c44bde59b1f2f23ddc970394079768f774fc007b700f156"
+hash = "0c58883ff5c0ed747a6cae86f4b50dd715063712d79ca698a96ebb6b44eabf9a"
 metafile = true
 
 [[files]]
 file = "mods/sc-peripherals.pw.toml"
-hash = "5ee4d78508bf6072054ebbf8bd11c61885c46aa199635059da0ac1dc64fc8785"
+hash = "2a0992abda997e608b1326278ccc2a7b7c842ebec22761fbbf7b4ce589f27b42"
 metafile = true
 
 [[files]]
 file = "mods/scriptor-magicae.pw.toml"
-hash = "d31374d6eac4eb842fca5a5aea68d90da9e6a6c919b8d480310dab32f9136721"
+hash = "ac7e9616d8e625fc44d767be2416046f2baad88ecf05178d43d40d9bf2aead6f"
 metafile = true
 
 [[files]]
 file = "mods/searchables.pw.toml"
-hash = "1fe2b3aa3fb54a4c449935c7cd74c8a3af1a342e6974bf6154916908ad861d1f"
+hash = "448a97d09f7817753963a334a0ca3defc34532f65ca4c7dfeec686146b1a54fe"
 metafile = true
 
 [[files]]
 file = "mods/servercore.pw.toml"
-hash = "b9eb5237b412cdae4005301af44f6b2298cb3b6f53cfd93456cf9c7833ad6a4b"
+hash = "6671525b7ffe9d80ebee7b397ee223e28cb8f288e8a1cca33687ea48e0efa020"
 metafile = true
 
 [[files]]
 file = "mods/simple-cobblestone-generator.pw.toml"
-hash = "3bb4f2b66a4cf607556e88894978100e7c1d58effe96b7df7d7e21118043d807"
+hash = "8aa4e05740bf541009d5d421e9044a7ae0c4cfe8bf89a650188af3affadd86e1"
 metafile = true
 
 [[files]]
 file = "mods/simple-voice-chat.pw.toml"
-hash = "4ddabe0943463aed08fcfe20880a525cc722ca8689692d5403e2c34c2c13b2d3"
+hash = "84f983e6cb000633117d3a57e317518571fb5caa7b6bf5da5cef5e1100bde390"
 metafile = true
 
 [[files]]
 file = "mods/sodium.pw.toml"
-hash = "20dcd5da980450c1243e1ce4e8bb5c95030dc4d3f246be7c3dbfbbae1a45cec9"
+hash = "7a8cd1f271f4825d61dff9d08194c6fdacace4f2a18238110ed79731577685dc"
 metafile = true
 
 [[files]]
 file = "mods/spark.pw.toml"
-hash = "96e3771cd09bb4a808d1c1fcb5a050efdc2ffb4efe7b584407ed54c46c0388d9"
+hash = "533fdff97be07a2cd0895d71f99f5f5af4c42a8b88f84f8072a3399e5c22a328"
 metafile = true
 
 [[files]]
 file = "mods/spectrum.pw.toml"
-hash = "49df6b5421c0576ffd3774a6314a03ae32d14a5308fd50c8a67c46f5865098ab"
+hash = "b527bd58f9a630ed912031ae37465f44daee74c83bb030219ab72e57d94be331"
 metafile = true
 
 [[files]]
 file = "mods/supermartijn642s-config-lib.pw.toml"
-hash = "075b0a946ee6bc32d2eadde90257bdf53d09493978b3b7add5af49716691799e"
+hash = "4130af71672a757a7a1c41a6200f1cda96fff172c73bc4adf50f6b40db723550"
 metafile = true
 
 [[files]]
 file = "mods/supermartijn642s-core-lib.pw.toml"
-hash = "1c016f800988efb78998ad081203e9789f720d9ae81826fd8c191eecdcc15ad3"
+hash = "7b8feba469600de05b5eaa6f596c0f46a9e615d9d639d615597932c4bedf6858"
 metafile = true
 
 [[files]]
 file = "mods/supplementaries.pw.toml"
-hash = "70de617c45937f523b14205f03c42d86c0dcbfa02032d5a49e650816c14bdcc0"
+hash = "1df412b51b7a03f6db10f16095b507e3f82d12efa31afec07bad27ce26b82470"
 metafile = true
 
 [[files]]
 file = "mods/toms-peripherals.pw.toml"
-hash = "9e85fda7c9a9f6f961f920d09b8214115d6e783c3fd40a6a4449024d05fcdcdc"
+hash = "cfa59f9d3c481cedf27bec7ba75a9d4730139984dd7c6d963d735289c2fb7bc6"
 metafile = true
 
 [[files]]
 file = "mods/tooltipfix.pw.toml"
-hash = "fe592547ec2aedf1de7add34f747f7845e103de228e2426328e9e60fe93298cc"
+hash = "688b537cce10045f249d27a51077bc2f29b9ade21d11d5ee9338480d13dd9117"
 metafile = true
 
 [[files]]
 file = "mods/tree-harvester.pw.toml"
-hash = "0cfda946dddf3020188f4521a8a9467134ce5cc7bb1cce6f0beaff2406d98044"
+hash = "febbc244e343aa75f09235eff3674ac6f9da4b6d18902b0d382832467de8de58"
 metafile = true
 
 [[files]]
 file = "mods/trinkets.pw.toml"
-hash = "b2e02d1210f025b905299bfc88f895058640158343322641aca2c4875622c992"
+hash = "54ebb0e40056ff441593cddadd91b8804689f1352ab33cd4dda44a0be0988713"
 metafile = true
 
 [[files]]
@@ -524,59 +529,59 @@ hash = "d6818563cd19a99b030e616203d914dafd666d17902e3ea40598cbd91bcf93af"
 
 [[files]]
 file = "mods/unloaded-activity.pw.toml"
-hash = "d7d0855a260bdad210b3ec58246ff5686ba4e12d03c441dd67653bea4c2e309b"
+hash = "8a53aa419a7e987bafd45a8651398b8398302b9f8a73ef844f5889bfe5a6dfa0"
 metafile = true
 
 [[files]]
 file = "mods/uwufied.pw.toml"
-hash = "b86b8eeb5bd448cb22d8005ef1a909b68e67ade61f93a9fa930c9efb86156909"
+hash = "af9bbf4fb787b3d1e94ea1b72977dd2f263cb53fe0b7f4e50fed06023b62b45d"
 metafile = true
 
 [[files]]
 file = "mods/vein-mining.pw.toml"
-hash = "af8a83655e6c01ad4b4116696642e36fe330fe3505f1e4c1c1c915d800aaa51a"
+hash = "6efdaa111f978d19e708dd0833488700832157a9beed14d90cc91d462ceb381a"
 metafile = true
 
 [[files]]
 file = "mods/vivecraft.pw.toml"
-hash = "cb5b3f2ac7b2f850a13ef6b39f7a46dfd5207d3828e337f3129efa33cffb6713"
+hash = "98970cb758b675af74b8c6e35058556c2cf087c5377aef71fd1c92c6fb89e50c"
 metafile = true
 
 [[files]]
 file = "mods/wearthat.pw.toml"
-hash = "3444df423ca287ea5b4be65d8696454ae410e030e918174d7102c22c9f29d25b"
+hash = "21dfca01f2252fcfa88d0d03d2794bbe186dbcade9932c0ca0abe01994c312e1"
 metafile = true
 
 [[files]]
 file = "mods/worldedit.pw.toml"
-hash = "bd1dc13316e2aa9b56c89e7e974057f8da8d6bbfe707ba4210109fc612b782e3"
+hash = "60d3e204f35d248d8f31abdc958ded8818b73ee21bed4ab694623428965acd6f"
 metafile = true
 
 [[files]]
 file = "mods/xaeros-map-chest-tracker-integration.pw.toml"
-hash = "d2e4f9b46b78fbb5939ecea89a5104b6291809732b5d01ac39b0efdb0dfaabb6"
+hash = "15483232e312eba034152e39d5fe788bfde6163680ddf2fcfb18a292722f0a4a"
 metafile = true
 
 [[files]]
 file = "mods/xaeros-minimap.pw.toml"
-hash = "4c176f305e2b3c52b47c58d252a0e46e4a8d4b89043385090dae3e40e91ba0f9"
+hash = "57a752821a37f1de9a01bbe8abe813d8057b1e7e8c5d97b4fa6d25e58d65ebe8"
 metafile = true
 
 [[files]]
 file = "mods/xaeros-world-map.pw.toml"
-hash = "d71dabaf362ddbae6f8fd3a8bb648b20b57bde93a1a59232c98da9e5403203d6"
+hash = "7cf97af587c8f169c0d39bdef24a4ebcf3fa3e43e3b5cd61ecddbe02c584f35d"
 metafile = true
 
 [[files]]
 file = "mods/yacl.pw.toml"
-hash = "fade244d31c2deeb9ea1b3f698e56595b894f3ea7df3734463ee627d31860d79"
+hash = "b7f0e77ae9d03819b7be241fe66ecb8567b4244a81e7440050ec2d232ca23710"
 metafile = true
 
 [[files]]
 file = "mods/yigd.pw.toml"
-hash = "6433aa1337792bf2e812b76acf2f92e1a8113287d1978e3ca89498783e672f79"
+hash = "b2cd8dda4d089c807111854440542d519b07928020b8cde89325382c0bd85db8"
 metafile = true
 
 [[files]]
 file = "readme.md"
-hash = "867e0e39c91aa976cb7cde8647f15bb31aff3baccdac7e6f3d16a244395355e1"
+hash = "35e4f507bfafa5179b55b6d93f4387b89a0ebff4e9190986efb381b68842585d"

--- a/mods/ftb-chunks-fabric.pw.toml
+++ b/mods/ftb-chunks-fabric.pw.toml
@@ -1,0 +1,18 @@
+name = "FTB Chunks (Fabric)"
+filename = "ftb-chunks-fabric-2001.3.0.jar"
+side = "both"
+
+[option]
+optional=true
+default=true
+description="FTB chunks"
+
+[download]
+hash-format = "sha1"
+hash = "901024f619bbe755eca149e6c64275d530155311"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 5267363
+project-id = 472657

--- a/mods/ftb-library-fabric.pw.toml
+++ b/mods/ftb-library-fabric.pw.toml
@@ -2,11 +2,6 @@ name = "FTB Library (Fabric)"
 filename = "ftb-library-fabric-2001.2.1.jar"
 side = "both"
 
-[option]
-optional=true
-default=false
-description="FTB library"
-
 [download]
 hash-format = "sha1"
 hash = "4b909afef8f74b3e95b167906c0ab2ee2c91f898"

--- a/mods/ftb-teams-fabric.pw.toml
+++ b/mods/ftb-teams-fabric.pw.toml
@@ -2,11 +2,6 @@ name = "FTB Teams (Fabric)"
 filename = "ftb-teams-fabric-2001.3.0.jar"
 side = "both"
 
-[option]
-optional=true
-default=true
-description="FTB teams"
-
 [download]
 hash-format = "sha1"
 hash = "a565eba19816d7ab388901dd92da8c7f4a9448b6"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "0836008f6a35821320ee62e082482b6fc9eacee8010ba805fcbbe606fcb50ec8"
+hash = "fe619e6cb1ceee8aa4f47140a0ca09710c10518f7216dfad5a88a3517b14b035"
 
 [versions]
 fabric = "0.15.9"


### PR DESCRIPTION
also fixed: FTB-chunks' dependencies should not be optional; the server requires them in order for you to connect.

NOTE: I would make FTB-chunks default to false but I feel like Chloe's server might disable it next restarted if I do. Is there a way to make the default separate for client and server? The main motive for making it default on the client is RAM usage but this is less of an issue for the server.